### PR TITLE
Allow other types of screen connections

### DIFF
--- a/camplayer/utils/utils.py
+++ b/camplayer/utils/utils.py
@@ -147,8 +147,7 @@ def get_display_mode(display=2):
         response = subprocess.check_output(
             ['tvservice', '--device', str(display), '--status'],
             stderr=subprocess.STDOUT).decode().splitlines()[0]
-
-        tmp = re.search('^state.+HDMI.(\S+).*\((\d+)\)[\s*\S*]* (\d+)x(\d+).+@ (\d+)', response)
+        tmp = re.search('^state.+(\S+).*\((\d+)\)[\s*\S*]* (\d+)x(\d+).+@ (\d+)', response)
         if tmp:
             hdmi_group  = tmp.group(1)
             hdmi_mode   = int(tmp.group(2))


### PR DESCRIPTION
When using a screen with a HDMI to DVI adapter, `tvservice` returns the following:
```
pi@raspberrypi:~ $ tvservice --device 2 --status
state 0x6 [DVI DMT (58) RGB full 16:10], 1680x1050 @ 60.00Hz, progressive
```

This is not matched by the regex that only looks for HDMI screens, which leads to the resolution not being set correctly.