### PR TITLE
Detect older DVI monitors and rotated screens

### DIFF
--- a/camplayer/utils/utils.py
+++ b/camplayer/utils/utils.py
@@ -157,6 +157,13 @@ def get_display_mode(display=2):
             res_width   = int(tmp.group(3))
             res_height  = int(tmp.group(4))
             framerate   = int(tmp.group(5))
+        else:
+            tmp = re.search('^state.+(CUSTOM).*[\s*\S*]* (\d+)x(\d+).+@ (\d+)', response)
+            if tmp:
+                hdmi_group  = tmp.group(1)
+                res_width   = int(tmp.group(2))
+                res_height  = int(tmp.group(3))
+                framerate   = int(tmp.group(4))
 
         response = subprocess.check_output(
             ['tvservice', '--device', str(display), '--name'],

--- a/camplayer/utils/utils.py
+++ b/camplayer/utils/utils.py
@@ -174,6 +174,25 @@ def get_display_mode(display=2):
     except:
         pass
 
+    try:
+        # correct/get resolution from framebuffer in case of 90 degree rotated screens
+        # In fact I wonder if we even need above tvservice call as fbset also works
+        # when HDMI is disconnected or blanked, and it works if only HDMI1 is connected
+        # without having to configure such in config.ini
+        # TODO nicer way to link hardware device and framebuffer
+        framebuffer = '/dev/fb0'
+        if display == 7:
+            framebuffer = '/dev/fb1'
+        response = subprocess.check_output(
+            ['fbset', '-fb', framebuffer, '--show'],
+            stderr=subprocess.STDOUT).decode()
+        tmp = re.search('geometry\s(\d+)\s(\d+)', response)
+        if tmp:
+            res_width   = int(tmp.group(1))
+            res_height  = int(tmp.group(2))
+    except:
+        pass
+
     return {'hdmi_group': hdmi_group, 'hdmi_mode': hdmi_mode, 'res_width': res_width,
             'res_height': res_height, 'framerate': framerate, 'device_name': device_name}
 


### PR DESCRIPTION
I have several old DVI monitors, of 3 types even,  that all 3 result in `tvservice -s` yielding `state 0x6 [DVI CUSTOM RGB full unknown AR], 1440x900 @ 60.00Hz, progressive` which needed a tweak to be processed by utils.py.

Additionally, as I rotate the screen in a 1x2 and 1x3 configuration, I also added a `fbdev --show` method to detect the rotated screen, which may in fact make entire `tvservice` no longer needed, I think `fbset` works in all cases anyway.

Anyway, did a minimal change, adding `fbset` but not modifying the original `tvservice` call